### PR TITLE
Fix link

### DIFF
--- a/index.html
+++ b/index.html
@@ -917,7 +917,7 @@
 
         <p><a href="https://www.youtube.com/watch?v=LqOcx-CtN0w&feature=youtu.be">GitHub Pull Requests for Everyone </a> (talk by Catherine Meade as JSConf 2018)</p>
 
-        <p><a href="https://tech.gsa.gov/assets/downloads/techtalks/GitHub-TechTalk-Sara-Nov2017.pdf">A Tour of GitHub for Non-Developers</a>(talk by Sara Cope for GSA)</p>
+        <p><a href="https://tech.gsa.gov/assets/files/techtalks/GitHubforNondevelopers2.pdf">A Tour of GitHub for Non-Developers</a>(talk by Sara Cope for GSA)</p>
 
       </div>
     </div>


### PR DESCRIPTION
Fixed the link to `A Tour of GitHub for Non-Developers(talk by Sara Cope for GSA)` on slide 61.